### PR TITLE
Fixed parent not defined when calling updateTransform on a container with no parent

### DIFF
--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -419,7 +419,7 @@ export default class Container extends DisplayObject
         }
 
         // TODO: check render flags, how to process stuff here
-        this.worldAlpha = this.alpha * this.parent.worldAlpha;
+        this.worldAlpha = this.alpha * (this.parent ? this.parent.worldAlpha : 1);
 
         for (let i = 0, j = this.children.length; i < j; ++i)
         {

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -413,7 +413,10 @@ export default class Container extends DisplayObject
 
         this._boundsID++;
 
-        this.transform.updateTransform(this.parent.transform);
+        if (this.parent)
+        {
+            this.transform.updateTransform(this.parent.transform);
+        }
 
         // TODO: check render flags, how to process stuff here
         this.worldAlpha = this.alpha * this.parent.worldAlpha;

--- a/packages/display/test/Container.js
+++ b/packages/display/test/Container.js
@@ -505,6 +505,19 @@ describe('PIXI.Container', function ()
 
             expect(canvasSpy).to.not.have.been.called;
         });
+
+        it('should succeed when called on a top level container', function ()
+        {
+            const container = new Container();
+            const child = new Container();
+            const canvasSpy = sinon.spy(child, 'updateTransform');
+
+            container.addChild(child);
+
+            container.updateTransform();
+
+            expect(canvasSpy).to.have.been.called;
+        });
     });
 
     describe('render', function ()


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
I added checks for a missing parent to Container.updateTransform to prevent reference errors when calling it on a container with no parent. It can currently be worked around by wrapping the top level container you want to call updateTransform on in another container, but that should probably not be necessary and the documentation makes no mention of requiring a parent.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
